### PR TITLE
Adds scope to initial OAuth request

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,5 +36,8 @@ DEPENDENCIES
   sinatra
   thin
 
+RUBY VERSION
+   ruby 2.2.3p173
+
 BUNDLED WITH
-   1.10.6
+   1.13.0

--- a/app.rb
+++ b/app.rb
@@ -33,13 +33,13 @@ post "/new" do
                 attachments: [
                   {
                     color: "00ACEF",
-                    text: "<https://slack.com/oauth/authorize?client_id=#{config[:client_id]}&state=#{state}&team=#{config[:slack_team_id]}|Click this link to start a new mailer>"
+                    text: "<https://slack.com/oauth/authorize?client_id=#{config[:client_id]}&state=#{state}&team=#{config[:slack_team_id]}&scope=channels:history|Click this link to start a new mailer>"
                   }
                 ]
               }
 
     response = HTTParty.post(params[:response_url], body: body.to_json, headers: headers)
-    puts response
+    puts "Request complete"
   end
 end
 


### PR DESCRIPTION
Adds `channels:history` scope to OAuth request. Scope is now a query string param required by Slack to accomplish authorization.
